### PR TITLE
chore: harden public repository safety

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scripts/public-safety-check.sh --staged

--- a/.github/workflows/public-safety.yml
+++ b/.github/workflows/public-safety.yml
@@ -1,0 +1,50 @@
+name: Public safety
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  public-safety:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan tracked files for public-safety issues
+        run: scripts/public-safety-check.sh --all
+
+  api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: api/package-lock.json
+      - name: Install API dependencies
+        working-directory: api
+        run: npm ci
+      - name: Typecheck API
+        working-directory: api
+        run: npm run typecheck
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,37 @@
+name: Secret scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan repository for secrets
+        id: scan
+        continue-on-error: true
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: true
+          GITLEAKS_ENABLE_SUMMARY: true
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_VERSION: latest
+
+      - name: Warn on findings
+        if: steps.scan.outcome == 'failure'
+        run: |
+          echo "::warning::Gitleaks found potential secrets. Review the job summary and PR comments."

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,20 @@ yarn-error.log*
 # misc
 *.pem
 *.tsbuildinfo
+*.bundle
+*.dump
+*.bak
+*.backup
+*.db
+*.sqlite
+*.sqlite3
+*.sqlite-*
 
 # database backups (contain data, not code)
 **/backups/*.sql
+**/backups/**
+**/*backup*.sql
+**/*dump*.sql
 api/backups/
 
 # local sync config

--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ Before making your fork public:
 For the ongoing public-repo workflow, backup boundaries, and new-window handoff
 rules, see [`docs/public-maintenance.md`](./docs/public-maintenance.md).
 
+Install the local public-safety hook before committing from a fresh clone:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The hook runs `scripts/public-safety-check.sh --staged`. GitHub Actions runs the
+same safety scan on tracked files plus API/frontend validation.
+
+To rotate the deployed admin password from a trusted terminal:
+
+```bash
+./scripts/change-admin-password.sh https://your-pages-site.pages.dev/api
+```
+
 ## Known Limits
 
 - Video upload is still disabled until the R2 Range read path is fully validated for production.

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -7,12 +7,12 @@ import { Env, SessionData } from '../types';
 import { authMiddleware, getSessionOptions } from '../middleware/auth';
 
 const loginSchema = z.object({
-  password: z.string().min(1),
+  password: z.string().min(1).max(256),
 });
 
 const changePasswordSchema = z.object({
-  oldPassword: z.string().min(1),
-  newPassword: z.string().min(6),
+  oldPassword: z.string().min(1).max(256),
+  newPassword: z.string().min(12).max(256),
 });
 
 const isAdminBootstrapAllowed = (env: Env) => env.ALLOW_ADMIN_BOOTSTRAP === 'true';

--- a/docs/public-maintenance.md
+++ b/docs/public-maintenance.md
@@ -68,30 +68,72 @@ private bucket, not this repo.
 Use this flow for future code changes:
 
 1. Edit source files.
-2. Run validation:
+2. Install the local git hook once per clone:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+3. Run validation:
 
 ```bash
 cd api && npm run typecheck
 cd ../frontend && npm run lint && npm run build
 ```
 
-3. Scan the staged diff:
+4. Stage only source changes, then run the public-safety scan:
+
+```bash
+./scripts/public-safety-check.sh --staged
+```
+
+The pre-commit hook runs the same staged scan automatically. GitHub Actions runs
+the full tracked-file scan plus API/frontend validation on pushes and pull
+requests.
+
+5. Scan the staged diff:
 
 ```bash
 git diff --cached
 git diff --cached --name-only
 ```
 
-4. Scan the repository for accidental private values:
+6. When changing public-safety rules, scan all tracked files and the current
+   worktree including untracked non-ignored files:
 
 ```bash
-git grep -n -I -E "password|secret|token|private_key|latitude|longitude|192\\.168\\.|workers\\.dev|pages\\.dev"
+./scripts/public-safety-check.sh --all
+./scripts/public-safety-check.sh --worktree
 ```
 
-Review each match. Placeholders and documentation examples are acceptable only
-when they are generic and not personally identifying.
+Review any failure before committing. Placeholders and documentation examples
+are acceptable only when they are generic and not personally identifying.
 
-5. Commit only after the working tree contains source changes, not local data.
+7. Commit only after the working tree contains source changes, not local data.
+
+## Password Rotation
+
+The admin password is stored in D1 as a bcrypt hash in `users.password_hash`.
+It is not a Cloudflare secret and should never be written to `.dev.vars`,
+`.env.local`, `wrangler.toml`, sync config, README, or issue text.
+
+Use the deployed HTTPS site or API endpoint to change it. Do not paste the new
+password into chat or commit it. The `/auth/change-password` endpoint requires an
+authenticated session and rejects new passwords shorter than 12 characters.
+
+From a trusted terminal, rotate the production password with:
+
+```bash
+./scripts/change-admin-password.sh https://your-pages-site.pages.dev/api
+```
+
+The script prompts with hidden input. It refuses non-HTTPS API URLs except
+localhost development URLs.
+
+For production, browser requests should go to the Cloudflare Pages HTTPS site
+and use the same-origin `/api` proxy. In that deployment shape, the password is
+sent over HTTPS to Cloudflare, not as plaintext over the network. The login input
+is a password field so it is not displayed on screen while typing.
 
 ## Public Release Check
 

--- a/docs/public-maintenance.md
+++ b/docs/public-maintenance.md
@@ -91,6 +91,11 @@ The pre-commit hook runs the same staged scan automatically. GitHub Actions runs
 the full tracked-file scan plus API/frontend validation on pushes and pull
 requests.
 
+An additional GitHub Actions secret scanner runs in advisory mode first. It is
+intended to catch unknown secret formats before they become required checks.
+Once its false positive rate is understood, promote it to a required status
+check in the repository ruleset.
+
 5. Scan the staged diff:
 
 ```bash

--- a/frontend/src/components/LoginScreen.tsx
+++ b/frontend/src/components/LoginScreen.tsx
@@ -99,13 +99,13 @@ export function LoginScreen() {
               </label>
               <input
                 ref={passwordInputRef}
-                type="text"
+                type="password"
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
                 autoFocus
                 autoCapitalize="none"
                 autoCorrect="off"
-                autoComplete="off"
+                autoComplete="current-password"
                 spellCheck={false}
                 className="field-input w-full px-4 py-3"
                 placeholder="输入密码"

--- a/scripts/change-admin-password.sh
+++ b/scripts/change-admin-password.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE="${1:-}"
+
+if [[ -z "$API_BASE" ]]; then
+  printf 'API base URL, for example https://your-pages-site.pages.dev/api: '
+  read -r API_BASE
+fi
+
+API_BASE="${API_BASE%/}"
+
+if [[ "$API_BASE" != https://* && "$API_BASE" != http://localhost:* && "$API_BASE" != http://127.0.0.1:* ]]; then
+  echo "Refusing non-HTTPS API base outside localhost." >&2
+  exit 1
+fi
+
+json_string() {
+  node -e '
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => { process.stdout.write(JSON.stringify(input.replace(/\n$/, ""))); });
+'
+}
+
+prompt_secret() {
+  local label="$1"
+  local value
+  printf '%s: ' "$label" >&2
+  read -r -s value
+  printf '\n' >&2
+  printf '%s' "$value"
+}
+
+OLD_PASSWORD="$(prompt_secret 'Current admin password')"
+NEW_PASSWORD="$(prompt_secret 'New admin password')"
+NEW_PASSWORD_CONFIRM="$(prompt_secret 'Confirm new admin password')"
+
+if [[ "$NEW_PASSWORD" != "$NEW_PASSWORD_CONFIRM" ]]; then
+  echo "New passwords do not match." >&2
+  exit 1
+fi
+
+if (( ${#NEW_PASSWORD} < 12 )); then
+  echo "New password must be at least 12 characters." >&2
+  exit 1
+fi
+
+OLD_PASSWORD_JSON="$(printf '%s' "$OLD_PASSWORD" | json_string)"
+NEW_PASSWORD_JSON="$(printf '%s' "$NEW_PASSWORD" | json_string)"
+
+LOGIN_HEADERS="$(
+  printf '{"password":%s}' "$OLD_PASSWORD_JSON" |
+  curl -sS -D - -o /dev/null \
+    -X POST "$API_BASE/auth/login" \
+    -H 'Content-Type: application/json' \
+    --data-binary @-
+)"
+
+SESSION_COOKIE="$(
+  printf '%s\n' "$LOGIN_HEADERS" |
+    awk 'BEGIN { IGNORECASE = 1 } /^set-cookie:/ { sub(/\r$/, ""); sub(/^[^:]+:[[:space:]]*/, ""); sub(/;.*/, ""); print; exit }'
+)"
+
+if [[ -z "$SESSION_COOKIE" ]]; then
+  echo "Login failed or no session cookie was returned." >&2
+  exit 1
+fi
+
+STATUS="$(
+  printf '{"oldPassword":%s,"newPassword":%s}' "$OLD_PASSWORD_JSON" "$NEW_PASSWORD_JSON" |
+  curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST "$API_BASE/auth/change-password" \
+    -H 'Content-Type: application/json' \
+    -H "Cookie: $SESSION_COOKIE" \
+    --data-binary @-
+)"
+
+if [[ "$STATUS" != "200" ]]; then
+  echo "Password change failed with HTTP status $STATUS." >&2
+  exit 1
+fi
+
+echo "Password changed successfully."

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+git config core.hooksPath .githooks
+echo "Configured git hooks path: .githooks"

--- a/scripts/public-safety-check.sh
+++ b/scripts/public-safety-check.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:---staged}"
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+failures=()
+
+add_failure() {
+  failures+=("$1")
+}
+
+is_example_path() {
+  case "$1" in
+    *.example|*.example.*|*.sample|*.sample.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_allowed_sql() {
+  case "$1" in
+    api/src/db/schema.sql|api/scripts/init-db.sql|api/scripts/add-pinned-column.sql) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+list_files() {
+  if [[ "$MODE" == "--all" ]]; then
+    git ls-files -z
+  elif [[ "$MODE" == "--staged" ]]; then
+    git diff --cached --name-only --diff-filter=ACMR -z
+  elif [[ "$MODE" == "--worktree" ]]; then
+    git ls-files -z --cached --others --exclude-standard
+  else
+    echo "usage: $0 [--staged|--all|--worktree]" >&2
+    exit 2
+  fi
+}
+
+file_content() {
+  local path="$1"
+  if [[ "$MODE" == "--all" ]]; then
+    [[ -f "$path" ]] && cat -- "$path"
+  else
+    git show ":$path" 2>/dev/null || true
+  fi
+}
+
+is_text_file() {
+  local path="$1"
+  if [[ "$MODE" == "--all" ]]; then
+    [[ -f "$path" ]] && LC_ALL=C grep -Iq . "$path"
+  else
+    git show ":$path" 2>/dev/null | LC_ALL=C grep -Iq .
+  fi
+}
+
+scan_path() {
+  local path="$1"
+  local base
+  base="$(basename "$path")"
+
+  case "$path" in
+    */.env|*/.env.*|.env|.env.*)
+      if ! is_example_path "$path"; then
+        add_failure "$path: environment files must stay out of git"
+      fi
+      ;;
+    */.dev.vars|*/.dev.vars.*|.dev.vars|.dev.vars.*)
+      if ! is_example_path "$path"; then
+        add_failure "$path: Wrangler dev vars must stay out of git"
+      fi
+      ;;
+    scripts/obsidian-sync/sync.config.json)
+      add_failure "$path: Obsidian sync config contains private local paths and credentials"
+      ;;
+    */.obsidian/*|.obsidian/*)
+      add_failure "$path: Obsidian sync state must stay out of git"
+      ;;
+    */.wrangler/*|.wrangler/*)
+      add_failure "$path: Wrangler local state must stay out of git"
+      ;;
+    */backups/*|backups/*)
+      add_failure "$path: backup directories must stay out of git"
+      ;;
+  esac
+
+  case "$base" in
+    *.bundle)
+      add_failure "$path: git history backup bundles must stay out of git"
+      ;;
+    *.db|*.sqlite|*.sqlite3|*.sqlite-*|*.dump|*.bak|*.backup)
+      add_failure "$path: database/runtime backup files must stay out of git"
+      ;;
+    *.sql)
+      if ! is_allowed_sql "$path"; then
+        add_failure "$path: SQL files are blocked unless they are approved schema/migration source files"
+      fi
+      ;;
+  esac
+}
+
+scan_content() {
+  local path="$1"
+
+  is_example_path "$path" && return 0
+  is_text_file "$path" || return 0
+
+  local content
+  content="$(file_content "$path")"
+
+  if grep -En '/Users/(khamoro|agent01|Shared)(/|$)' <<<"$content" >/dev/null; then
+    add_failure "$path: contains a private absolute local path"
+  fi
+
+  if grep -En '\b(192\.168|10\.|172\.(1[6-9]|2[0-9]|3[0-1]))\.[0-9]{1,3}\.[0-9]{1,3}\b' <<<"$content" >/dev/null; then
+    add_failure "$path: contains a concrete private LAN IP"
+  fi
+
+  if grep -En 'database_id\s*=\s*"[0-9a-fA-F-]{24,}"' <<<"$content" >/dev/null; then
+    add_failure "$path: contains a concrete Cloudflare D1 database id"
+  fi
+
+  if grep -En 'account_id\s*=\s*"[0-9a-fA-F]{32}"' <<<"$content" >/dev/null; then
+    add_failure "$path: contains a concrete Cloudflare account id"
+  fi
+
+  if grep -En 'ENV_LATITUDE=(-?[1-9][0-9]*(\.[0-9]+)?|-?0\.[0-9]*[1-9][0-9]*)' <<<"$content" >/dev/null; then
+    add_failure "$path: contains a concrete latitude"
+  fi
+
+  if grep -En 'ENV_LONGITUDE=(-?[1-9][0-9]*(\.[0-9]+)?|-?0\.[0-9]*[1-9][0-9]*)' <<<"$content" >/dev/null; then
+    add_failure "$path: contains a concrete longitude"
+  fi
+
+  if grep -En '(SESSION_SECRET|SERVICE_TOKEN|API_TOKEN|PASSWORD|PRIVATE_KEY)\s*[:=]\s*["'\'']?[A-Za-z0-9_./+=@:-]{16,}' <<<"$content" | grep -Ev 'your-|REPLACE_|<|example|placeholder|min-32-characters' >/dev/null; then
+    add_failure "$path: contains a high-risk secret-like assignment"
+  fi
+
+  if grep -En 'https://[A-Za-z0-9.-]+\.(workers|pages)\.dev' <<<"$content" | grep -Ev 'your-|example|<|placeholder' >/dev/null; then
+    add_failure "$path: contains a concrete Cloudflare workers.dev/pages.dev URL"
+  fi
+}
+
+while IFS= read -r -d '' path; do
+  scan_path "$path"
+  scan_content "$path"
+done < <(list_files)
+
+if (( ${#failures[@]} > 0 )); then
+  printf 'Public safety check failed:\n' >&2
+  printf ' - %s\n' "${failures[@]}" >&2
+  exit 1
+fi
+
+echo "Public safety check passed ($MODE)."

--- a/scripts/public-safety-check.sh
+++ b/scripts/public-safety-check.sh
@@ -43,6 +43,8 @@ file_content() {
   local path="$1"
   if [[ "$MODE" == "--all" ]]; then
     [[ -f "$path" ]] && cat -- "$path"
+  elif [[ "$MODE" == "--worktree" ]]; then
+    [[ -f "$path" ]] && cat -- "$path"
   else
     git show ":$path" 2>/dev/null || true
   fi
@@ -51,6 +53,8 @@ file_content() {
 is_text_file() {
   local path="$1"
   if [[ "$MODE" == "--all" ]]; then
+    [[ -f "$path" ]] && LC_ALL=C grep -Iq . "$path"
+  elif [[ "$MODE" == "--worktree" ]]; then
     [[ -f "$path" ]] && LC_ALL=C grep -Iq . "$path"
   else
     git show ":$path" 2>/dev/null | LC_ALL=C grep -Iq .


### PR DESCRIPTION
## Summary
  - Add a staged/worktree/tracked public-safety scanner for secrets, paths, backups, and Cloudflare/private values.
  - Wire the scanner into a local git pre-commit hook and GitHub Actions.
  - Harden login input handling by switching the admin login field to a password input.
  - Enforce stronger password changes with a minimum length requirement.
  - Add a trusted-terminal password rotation script that does not write passwords to files or command arguments.
  - Update public maintenance docs and README with the new workflow.
  - Reorganize microblog Claude docs to fit the path architecture without deleting files.

  ## Verification
  - `scripts/public-safety-check.sh --all`
  - `scripts/public-safety-check.sh --worktree`
  - `cd api && npm run typecheck`
  - `cd frontend && npm run lint`
  - `cd frontend && npm run build`
  - `git diff --check`

  ## Notes
  - The admin password is stored as a bcrypt hash in D1, not in Cloudflare secrets.
  - The login page now uses a password field, so the password is not shown on screen while typing.